### PR TITLE
odri: bump + add ros-jazzy-odri shell 

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -135,6 +135,17 @@
                   ];
                 };
 
+                ros-jazzy-odri = pkgs.rosPackages.jazzy.buildEnv {
+                  name = "ros-jazzy-odri";
+                  postBuild = inputs.flakoboros.lib.rosWrapperArgs pkgs "jazzy" { };
+                  paths =
+                    lib.attrValues (lib.filterAttrs (n: _p: lib.hasPrefix "ros-jazzy-odri-" n) self'.packages)
+                    ++ [
+                      pkgs.python3Packages.coal # TODO
+                      pkgs.qt5.wrapQtAppsHook
+                    ];
+                };
+
                 ros-kilted = pkgs.rosPackages.kilted.buildEnv {
                   name = "ros-kilted";
                   postBuild = inputs.flakoboros.lib.rosWrapperArgs pkgs "kilted" { };

--- a/hashes.json
+++ b/hashes.json
@@ -105,6 +105,7 @@
   "https://github.com/stack-of-tasks/odri_dual_motor_testbed_robot/archive/ce808abcbf62df8417f23775db447d5f515ea443.tar.gz": "sha256-uf5wgrkdCvevNMEaVMnhthWuWcBx+7/RQg3GbnjWqDo=",
   "https://github.com/stack-of-tasks/odri_forward_command_controller/archive/791ff09a36d15c6f435650ef1685de0c801ca922.tar.gz": "sha256-vEpNhyLrKJx0F3gn6JAhpPfFXrFEbZKSoSraoMcrrAA=",
   "https://github.com/stack-of-tasks/odri_forward_command_controller/archive/fe9fd167cffeede19867b3d40acc839058d3174a.tar.gz": "sha256-RqPMTgF9CT6HX6kyF1fGj2kKkuoyNi8EcNb/+qDU++s=",
+  "https://github.com/stack-of-tasks/odri_gz_ros2_control/archive/4ec8d55778282b859f6b392e4f7dce35f3b73937.tar.gz": "sha256-vqXAN1fNIqjFvjktHOTfvcRqvySv5A986E0JFO5qc5Q=",
   "https://github.com/stack-of-tasks/odri_gz_ros2_control/archive/de7ef0888792ef3b4a75150a60ccf559947817db.tar.gz": "sha256-zc5GuiqPQnD6NHEAfdXfmUlqRcjznPqYdciweD/FQPg=",
   "https://github.com/stack-of-tasks/odri_gz_ros2_control/archive/f805c668c675fb0ce18abae7838c5daa2b900365.tar.gz": "sha256-JAU8DVsEpAXorZBGVAwvNKkKnN5b085u6DZ4CuPRoYM="
 }

--- a/hashes.json
+++ b/hashes.json
@@ -105,6 +105,7 @@
   "https://github.com/stack-of-tasks/odri_dual_motor_testbed_robot/archive/ce808abcbf62df8417f23775db447d5f515ea443.tar.gz": "sha256-uf5wgrkdCvevNMEaVMnhthWuWcBx+7/RQg3GbnjWqDo=",
   "https://github.com/stack-of-tasks/odri_forward_command_controller/archive/791ff09a36d15c6f435650ef1685de0c801ca922.tar.gz": "sha256-vEpNhyLrKJx0F3gn6JAhpPfFXrFEbZKSoSraoMcrrAA=",
   "https://github.com/stack-of-tasks/odri_forward_command_controller/archive/fe9fd167cffeede19867b3d40acc839058d3174a.tar.gz": "sha256-RqPMTgF9CT6HX6kyF1fGj2kKkuoyNi8EcNb/+qDU++s=",
+  "https://github.com/stack-of-tasks/odri_gz_ros2_control/archive/25575c5976013a909e0e8dd365ef441c419bcb45.tar.gz": "sha256-MIA/ZKyvOShXrqgWknjxtTnNsEjpN4cDl13gEeiPfgE=",
   "https://github.com/stack-of-tasks/odri_gz_ros2_control/archive/4ec8d55778282b859f6b392e4f7dce35f3b73937.tar.gz": "sha256-vqXAN1fNIqjFvjktHOTfvcRqvySv5A986E0JFO5qc5Q=",
   "https://github.com/stack-of-tasks/odri_gz_ros2_control/archive/de7ef0888792ef3b4a75150a60ccf559947817db.tar.gz": "sha256-zc5GuiqPQnD6NHEAfdXfmUlqRcjznPqYdciweD/FQPg=",
   "https://github.com/stack-of-tasks/odri_gz_ros2_control/archive/f805c668c675fb0ce18abae7838c5daa2b900365.tar.gz": "sha256-JAU8DVsEpAXorZBGVAwvNKkKnN5b085u6DZ4CuPRoYM="

--- a/hashes.json
+++ b/hashes.json
@@ -102,6 +102,9 @@
   "https://github.com/stack-of-tasks/odri_dual_motor_testbed_robot/archive/29aba95e25e22af7cdfb2f8932d6bd403f01f859.tar.gz": "sha256-kckcd5mqCttqABjLmxrnJYFB5Wbq2yF5vQjBRSUTqVo=",
   "https://github.com/stack-of-tasks/odri_dual_motor_testbed_robot/archive/2dda1bbfa90f459c2d9909c97aa5aab7052520ec.tar.gz": "sha256-aCFH13rwexeiUgVzwJ4l1D6bUUTJ5Oc5rDxOofjBf6E=",
   "https://github.com/stack-of-tasks/odri_dual_motor_testbed_robot/archive/97b06beb4753b3c6a1d64cf33c833d5bc9b9b0b5.tar.gz": "sha256-vsMkKL0bL04UkfUeEfL5+rx3pQa9jOEx2uGCIqxKHpU=",
+  "https://github.com/stack-of-tasks/odri_dual_motor_testbed_robot/archive/ce808abcbf62df8417f23775db447d5f515ea443.tar.gz": "sha256-uf5wgrkdCvevNMEaVMnhthWuWcBx+7/RQg3GbnjWqDo=",
+  "https://github.com/stack-of-tasks/odri_forward_command_controller/archive/791ff09a36d15c6f435650ef1685de0c801ca922.tar.gz": "sha256-vEpNhyLrKJx0F3gn6JAhpPfFXrFEbZKSoSraoMcrrAA=",
   "https://github.com/stack-of-tasks/odri_forward_command_controller/archive/fe9fd167cffeede19867b3d40acc839058d3174a.tar.gz": "sha256-RqPMTgF9CT6HX6kyF1fGj2kKkuoyNi8EcNb/+qDU++s=",
-  "https://github.com/stack-of-tasks/odri_gz_ros2_control/archive/de7ef0888792ef3b4a75150a60ccf559947817db.tar.gz": "sha256-zc5GuiqPQnD6NHEAfdXfmUlqRcjznPqYdciweD/FQPg="
+  "https://github.com/stack-of-tasks/odri_gz_ros2_control/archive/de7ef0888792ef3b4a75150a60ccf559947817db.tar.gz": "sha256-zc5GuiqPQnD6NHEAfdXfmUlqRcjznPqYdciweD/FQPg=",
+  "https://github.com/stack-of-tasks/odri_gz_ros2_control/archive/f805c668c675fb0ce18abae7838c5daa2b900365.tar.gz": "sha256-JAU8DVsEpAXorZBGVAwvNKkKnN5b085u6DZ4CuPRoYM="
 }

--- a/ros-pkgs/jazzy/odri-dual-motor-testbed-bringup.nix
+++ b/ros-pkgs/jazzy/odri-dual-motor-testbed-bringup.nix
@@ -46,8 +46,8 @@ buildRosPackage rec {
   src = fetchFromGitHub {
     owner = "stack-of-tasks";
     repo = "odri_dual_motor_testbed_robot";
-    rev = "97b06beb4753b3c6a1d64cf33c833d5bc9b9b0b5";
-    hash = "sha256-vsMkKL0bL04UkfUeEfL5+rx3pQa9jOEx2uGCIqxKHpU=";
+    rev = "ce808abcbf62df8417f23775db447d5f515ea443";
+    hash = "sha256-uf5wgrkdCvevNMEaVMnhthWuWcBx+7/RQg3GbnjWqDo=";
   };
   sourceRoot = "source/odri_dual_motor_testbed_bringup";
 

--- a/ros-pkgs/jazzy/odri-dual-motor-testbed-description.nix
+++ b/ros-pkgs/jazzy/odri-dual-motor-testbed-description.nix
@@ -45,8 +45,8 @@ buildRosPackage rec {
   src = fetchFromGitHub {
     owner = "stack-of-tasks";
     repo = "odri_dual_motor_testbed_robot";
-    rev = "97b06beb4753b3c6a1d64cf33c833d5bc9b9b0b5";
-    hash = "sha256-vsMkKL0bL04UkfUeEfL5+rx3pQa9jOEx2uGCIqxKHpU=";
+    rev = "ce808abcbf62df8417f23775db447d5f515ea443";
+    hash = "sha256-uf5wgrkdCvevNMEaVMnhthWuWcBx+7/RQg3GbnjWqDo=";
   };
   sourceRoot = "source/odri_dual_motor_testbed_description";
 

--- a/ros-pkgs/jazzy/odri-dual-motor-testbed-gazebo.nix
+++ b/ros-pkgs/jazzy/odri-dual-motor-testbed-gazebo.nix
@@ -38,8 +38,8 @@ buildRosPackage rec {
   src = fetchFromGitHub {
     owner = "stack-of-tasks";
     repo = "odri_dual_motor_testbed_robot";
-    rev = "97b06beb4753b3c6a1d64cf33c833d5bc9b9b0b5";
-    hash = "sha256-vsMkKL0bL04UkfUeEfL5+rx3pQa9jOEx2uGCIqxKHpU=";
+    rev = "ce808abcbf62df8417f23775db447d5f515ea443";
+    hash = "sha256-uf5wgrkdCvevNMEaVMnhthWuWcBx+7/RQg3GbnjWqDo=";
   };
   sourceRoot = "source/odri_dual_motor_testbed_gazebo";
 

--- a/ros-pkgs/jazzy/odri-dual-motor-testbed-robot.nix
+++ b/ros-pkgs/jazzy/odri-dual-motor-testbed-robot.nix
@@ -38,8 +38,8 @@ buildRosPackage rec {
   src = fetchFromGitHub {
     owner = "stack-of-tasks";
     repo = "odri_dual_motor_testbed_robot";
-    rev = "97b06beb4753b3c6a1d64cf33c833d5bc9b9b0b5";
-    hash = "sha256-vsMkKL0bL04UkfUeEfL5+rx3pQa9jOEx2uGCIqxKHpU=";
+    rev = "ce808abcbf62df8417f23775db447d5f515ea443";
+    hash = "sha256-uf5wgrkdCvevNMEaVMnhthWuWcBx+7/RQg3GbnjWqDo=";
   };
   sourceRoot = "source/odri_dual_motor_testbed_robot";
 

--- a/ros-pkgs/jazzy/odri-forward-command-controller.nix
+++ b/ros-pkgs/jazzy/odri-forward-command-controller.nix
@@ -33,8 +33,8 @@ buildRosPackage rec {
   src = fetchFromGitHub {
     owner = "stack-of-tasks";
     repo = "odri_forward_command_controller";
-    rev = "fe9fd167cffeede19867b3d40acc839058d3174a";
-    hash = "sha256-RqPMTgF9CT6HX6kyF1fGj2kKkuoyNi8EcNb/+qDU++s=";
+    rev = "791ff09a36d15c6f435650ef1685de0c801ca922";
+    hash = "sha256-vEpNhyLrKJx0F3gn6JAhpPfFXrFEbZKSoSraoMcrrAA=";
   };
   sourceRoot = "source/";
 

--- a/ros-pkgs/jazzy/odri-gz-ros2-control.nix
+++ b/ros-pkgs/jazzy/odri-gz-ros2-control.nix
@@ -44,8 +44,8 @@ buildRosPackage rec {
   src = fetchFromGitHub {
     owner = "stack-of-tasks";
     repo = "odri_gz_ros2_control";
-    rev = "f805c668c675fb0ce18abae7838c5daa2b900365";
-    hash = "sha256-JAU8DVsEpAXorZBGVAwvNKkKnN5b085u6DZ4CuPRoYM=";
+    rev = "4ec8d55778282b859f6b392e4f7dce35f3b73937";
+    hash = "sha256-vqXAN1fNIqjFvjktHOTfvcRqvySv5A986E0JFO5qc5Q=";
   };
   sourceRoot = "source/";
 

--- a/ros-pkgs/jazzy/odri-gz-ros2-control.nix
+++ b/ros-pkgs/jazzy/odri-gz-ros2-control.nix
@@ -7,7 +7,6 @@
   ament-cmake,
 
   # buildInputs
-  ament-index-cpp,
   controller-manager,
   gz-plugin-vendor,
   gz-sim-vendor,
@@ -15,6 +14,7 @@
   pluginlib,
   rclcpp,
   rclcpp-lifecycle,
+  ros2-control-cmake,
   yaml-cpp-vendor,
 
   # propagatedBuildInputs
@@ -23,6 +23,7 @@
   ament-cmake-copyright,
   ament-cmake-cppcheck,
   ament-cmake-cpplint,
+  ament-cmake-gtest,
   ament-cmake-lint-cmake,
   ament-cmake-xmllint,
   ament-lint-auto,
@@ -43,8 +44,8 @@ buildRosPackage rec {
   src = fetchFromGitHub {
     owner = "stack-of-tasks";
     repo = "odri_gz_ros2_control";
-    rev = "de7ef0888792ef3b4a75150a60ccf559947817db";
-    hash = "sha256-zc5GuiqPQnD6NHEAfdXfmUlqRcjznPqYdciweD/FQPg=";
+    rev = "f805c668c675fb0ce18abae7838c5daa2b900365";
+    hash = "sha256-JAU8DVsEpAXorZBGVAwvNKkKnN5b085u6DZ4CuPRoYM=";
   };
   sourceRoot = "source/";
 
@@ -58,7 +59,6 @@ buildRosPackage rec {
   ];
   buildInputs = [
     ament-cmake
-    ament-index-cpp
     controller-manager
     gz-plugin-vendor
     gz-sim-vendor
@@ -66,10 +66,10 @@ buildRosPackage rec {
     pluginlib
     rclcpp
     rclcpp-lifecycle
+    ros2-control-cmake
     yaml-cpp-vendor
   ];
   propagatedBuildInputs = [
-    ament-index-cpp
     controller-manager
     gz-plugin-vendor
     gz-sim-vendor
@@ -77,12 +77,14 @@ buildRosPackage rec {
     pluginlib
     rclcpp
     rclcpp-lifecycle
+    ros2-control-cmake
     yaml-cpp-vendor
   ];
   checkInputs = [
     ament-cmake-copyright
     ament-cmake-cppcheck
     ament-cmake-cpplint
+    ament-cmake-gtest
     ament-cmake-lint-cmake
     ament-cmake-xmllint
     ament-lint-auto

--- a/ros-pkgs/jazzy/odri-gz-ros2-control.nix
+++ b/ros-pkgs/jazzy/odri-gz-ros2-control.nix
@@ -44,8 +44,8 @@ buildRosPackage rec {
   src = fetchFromGitHub {
     owner = "stack-of-tasks";
     repo = "odri_gz_ros2_control";
-    rev = "4ec8d55778282b859f6b392e4f7dce35f3b73937";
-    hash = "sha256-vqXAN1fNIqjFvjktHOTfvcRqvySv5A986E0JFO5qc5Q=";
+    rev = "25575c5976013a909e0e8dd365ef441c419bcb45";
+    hash = "sha256-MIA/ZKyvOShXrqgWknjxtTnNsEjpN4cDl13gEeiPfgE=";
   };
   sourceRoot = "source/";
 

--- a/ros2nix.toml
+++ b/ros2nix.toml
@@ -134,8 +134,9 @@ do_check = false
 
 [jazzy."stack-of-tasks/odri_dual_motor_testbed_robot"]
 branch = "nix"
-[jazzy."stack-of-tasks/odri_forward_command_controller".packages]
-odri_forward_command_controller = {native = ["writableTmpDirAsHomeHook"]}
+[jazzy."stack-of-tasks/odri_forward_command_controller"]
+branch = "nix"
+packages = {odri_forward_command_controller = {native = ["writableTmpDirAsHomeHook"]}}
 [jazzy."stack-of-tasks/odri_gz_ros2_control"]
 branch = "nix"
 


### PR DESCRIPTION
```
┃        > pkgs.buildEnv error: two given paths contain a conflicting subpath:
┃        >   `/nix/store/q6rrx1q5xqnv05d981wciqrxhy6859mm-ros-jazzy-gz-ros2-control-1.2.19-r1/lib/libgz_ros2_control-s…
┃        >   `/nix/store/f7lcfi4cyrrh24h4winn4ia009jdri69-ros-jazzy-odri-gz-ros2-control-1.2.2/lib/libgz_ros2_control-…
```

@olivier-stasse : do we really want to override the lib from gz-ros2-control in odri-gz-ros2-control ?